### PR TITLE
Automatizing solr -- 1.0.0 solr6.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,9 @@
-FROM ubuntu:trusty
+FROM java:8
 
 MAINTAINER Juergen Jakobitsch <jakobitschj@semantic-web.at>
+MAINTAINER Ivan Ermilov <ivan.s.ermilov@gmail.com>
 
-RUN apt-get update && apt-get install -y wget unzip software-properties-common vim lsof
-
-RUN  add-apt-repository -y ppa:webupd8team/java
-RUN  apt-get update
-RUN  echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN  apt-get -y install oracle-java8-installer
-RUN  apt-get -y install oracle-java8-set-default
-
-RUN /bin/bash -c "source /etc/profile.d/jdk.sh"
-
-RUN rm -f /var/cache/oracle-jdk8-installer/jdk-8u72-linux-x64.tar.gz
-
-ENV SOLR_VERSION="5.4.1"
+ENV SOLR_VERSION="6.0.1"
 ENV APPLICATION_ROOT="/usr/local/apache-solr"
 
 RUN mkdir -p $APPLICATION_ROOT 
@@ -24,7 +13,10 @@ RUN ln -s $APPLICATION_ROOT/solr-${SOLR_VERSION} /usr/local/apache-solr/current
 ENV SOLR_HOME=/usr/local/apache-solr/current
 RUN cd $APPLICATION_ROOT && rm -f solr-${SOLR_VERSION}.tgz
 
-#ADD solr-5.4.1.tgz /usr/local/apache-solr/
-#RUN ln -s /usr/local/apache-solr/solr-5.4.1 /usr/local/apache-solr/current
-#ENV SOLR_HOME="/usr/local/apache-solr/current"
-#RUN rm -f /tmp/solr-5.4.1.tgz
+ADD entrypoint.sh /entrypoint.sh
+RUN chmod a+x /entrypoint.sh
+ADD run.sh /run.sh
+RUN chmod a+x /run.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/run.sh"]

--- a/README.md
+++ b/README.md
@@ -3,105 +3,35 @@
 Docker image containing a standard Solr distribution.
 
 Versions used in this docker image:
-* Solr Version: 5.4.1
+* Solr Version: 6.0.1
 * Java 1.8.0_72
 
 Image details:
 * Installation directory: /usr/local/apache-solr/current
 
-## Solr Docker image
+## Using with docker-compose
 
-To start the Solr Docker image:
-
-    docker run -i -t bde2020/solr /bin/bash
-    
-To build the Solr Docker image:
-
- ```bash
-git clone https://github.com/big-data-europe/solr.git
-docker build -t bde2020/solr .
+The minimal configuration includes an instance of zookeeper with 1
 ```
-To create a distributed Solr index.
-* Upload Solr configuration to zookeeper
-  To bootstrap the Solr configuration inside zookeeper the following files are required
-  * security.json
-  * clusterprops.json
-  * solr.xml
-  
-  It is possible to use any available tool to upload these file to zookeeper. 
-  The recommended way is to use Solr's zkcli.sh to upload Solr configuration files. This script offers the possibility to upload a whole config directory at once to zookeeper. The script is available inside a running docker image under /usr/local/apache-solr/current/server/scripts/cloud-scripts. 
-  The following commands upload a sample configuration from the Solr distribution and solr.xml (must be in zookeeper chroot) to zookeeper
-  ```bash
-./zkcli.sh \
-  -zkhost 192.168.88.219:2181/solr \
-  -cmd upconfig \
-  -confdir ../../solr/configsets/basic_configs/conf/ \
-  -confname basic_config
-```
-  ```bash
-./zkcli.sh \
-  -zkhost 192.168.88.219:2181/solr \
-  -cmd putfile /solr.xml ../../solr.xml 
-```
-  see: https://cwiki.apache.org/confluence/display/solr/Using+ZooKeeper+to+Manage+Configuration+Files for more information on setting up Solr's configuration in zookeeper.
-  
-* Start Solr Cloud
-  
-  If the above required config files are present in a zookeeper node it is possible to start Solr in cloud mode.
-  Use the following command to startup Solr in cloud mode. Note that it is recommended to use a mapped directory
-  as Solr home (this will ensure that indexes survive a docker image restart). For this guide it is assumed that
-  /var/lib/bde/solr will act as Solr home and that said directory is mapped to the host where the docker image runs.
-  In case it doesn't already exist, the directory can be created with
-  ```bash
-mkdir -p /var/lib/solr
-```
-  Solr Cloud is started with the following command. Notes: -f = run in foreground, -cloud = run in cloud mode, -s = use the specified directory as Solr home, -p = the port Solr will be available trough, -z = the zookeeper path with chroot
-  ```bash
-cd /usr/local/apache-solr/current && \
-.bin/solr start \
-  -f \
-  -cloud \
-  -s /var/lib/solr \
-  -p 8983 \
-  -z 192.168.88.219:2181,192.168.88.220:2181,192.168.88.221:2181/solr
-```
+version: '2'
+services:
+  solr:
+    image: earthquakesan/solr:1.0.0-solr6.0.1
+    hostname: solr
+    environment:
+      - ZOOKEEPER_HOST=zookeeper:2181
+    networks:
+      - solr
+    ports:
+      - "8983:8983"
+  zookeeper:
+    image: mesoscloud/zookeeper:3.4.8-centos-7
+    hostname: zookeeper
+    networks:
+      - solr
+    environment:
+      - MYID=1
 
-* Use Solr's HTTP API to create a the distributed index
-
-  To create a distributed (sharded) index it is now possible to use Solr's HTTP API.
-  ```bash
-  http://bigdata-one.example.com:8983/solr/admin/collections?action=CREATE&name=SampleCollection&numShards=3&replicationFactor=1&collection.configName=basic_config
-```
-  Notes: With the above service call a new collection is created, it's name is SampleCollection, the number of shards is three, a replication factor of 1 is used and the collection will be based on the "basic_config" configuration, that was uploaded to zookeeper in the previous step.
-
-To start Solr Docker image on Marathon:
-
-* Create a Marathon Application Setup in json like the one below, store it in a file (e.g. marathon-solr.json) and post it to Marathon's v2/app endpoint.
-
- ```json
-{
-    "container": {
-        "type": "DOCKER",
-        "volumes": [
-        {
-                "containerPath": "/var/lib/solr",
-                "hostPath": "/var/lib/bde/solr",
-                "mode": "RW"
-        }
-        ],
-        "docker": {
-            "network": "HOST",
-            "privileged":true,
-            "image": "bde2020/solr"
-        }
-    },
-    "id":"apache-solr",
-    "mem": 1024,
-    "cpus":0.3,
-    "cmd": "mkdir -p /var/lib/solr && /usr/local/apache-solr/current/bin/solr start -f -cloud -s /var/lib/solr -p 8983 -z 192.168.88.219:2181,192.168.88.220:2181,192.168.88.221:2181/solr",
-    "instances":0,
-    "requirePorts":true,
-    "ports":[8983,7983],
-    "constraints":[["hostname","UNIQUE",""]]
-}
+networks:
+  solr:
 ```

--- a/commands.sh
+++ b/commands.sh
@@ -1,0 +1,11 @@
+./zkcli.sh -zkhost zookeeper:2181/solr -cmd upconfig -confdir ../../solr/configsets/basic_configs/conf/ -confname basic_config
+./zkcli.sh -zkhost zookeeper:2181/solr -cmd putfile /solr.xml ../../solr/solr.xml
+mkdir -p /var/lib/solr
+
+cd /usr/local/apache-solr/current && \
+  bin/solr start \
+  -f \
+  -cloud \
+  -s /var/lib/solr \
+  -p 8983 \
+  -z zookeeper:2181/solr

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+zkcli=$SOLR_HOME/server/scripts/cloud-scripts/zkcli.sh 
+SOLR_CONFIG_DIR=$SOLR_HOME/server/solr/configsets/basic_configs/conf/
+
+mkdir -p /var/lib/solr
+$zkcli -zkhost zookeeper:2181/solr -cmd upconfig -confdir $SOLR_CONFIG_DIR -confname basic_config
+$zkcli -zkhost zookeeper:2181/solr -cmd putfile /solr.xml $SOLR_HOME/server/solr/solr.xml
+
+exec $@

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@ zkcli=$SOLR_HOME/server/scripts/cloud-scripts/zkcli.sh
 SOLR_CONFIG_DIR=$SOLR_HOME/server/solr/configsets/basic_configs/conf/
 
 mkdir -p /var/lib/solr
-$zkcli -zkhost zookeeper:2181/solr -cmd upconfig -confdir $SOLR_CONFIG_DIR -confname basic_config
-$zkcli -zkhost zookeeper:2181/solr -cmd putfile /solr.xml $SOLR_HOME/server/solr/solr.xml
+$zkcli -zkhost $ZOOKEEPER_HOST/solr -cmd upconfig -confdir $SOLR_CONFIG_DIR -confname basic_config
+$zkcli -zkhost $ZOOKEEPER_HOST/solr -cmd putfile /solr.xml $SOLR_HOME/server/solr/solr.xml
 
 exec $@

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+SOLR_BIN=$SOLR_HOME/bin/solr
+$SOLR_BIN start -f -cloud -s /var/lib/solr -p 8983 -z zookeeper:2181/solr

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 SOLR_BIN=$SOLR_HOME/bin/solr
-$SOLR_BIN start -f -cloud -s /var/lib/solr -p 8983 -z zookeeper:2181/solr
+$SOLR_BIN start -f -cloud -s /var/lib/solr -p 8983 -z $ZOOKEEPER_HOST/solr


### PR DESCRIPTION
Hi Juergen!

I automatized the instructions you provided in the README file and updated to SOLR "6.0.1" version. Also, I use java:8 as base, which results in a smaller image size. Please merge this branch into the repository.

I propose to move the current master branch to something like 1.0.0-solr5.4.1 and merge master branch with 1.0.0-solr6.0.1 (i.e. will be tag "latest" on the docker hub as well). Essentially, there should be 3 branches:
master -- the same as 1.0.0-solr6.0.1
1.0.0-solr5.4.1 -- the currect master
1.0.0-solr6.0.1 -- 1.0.0-solr6.0.1 (this pull request)

For trying out new solr setup, use docker-compose file from this repo: https://github.com/earthquakesan/demo-solr-minimal-setup

Kind regards,
Ivan.
